### PR TITLE
fix: Part1

### DIFF
--- a/Part1.ipynb
+++ b/Part1.ipynb
@@ -456,7 +456,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mplhep.hist2dplot(hist3d[:, :, sum]);"
+    "mplhep.hist2dplot(hist3d[:, :, sum].view());"
    ]
   },
   {


### PR DESCRIPTION
```python
mplhep.hist2dplot(hist3d[:, :, sum]);
```

```
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-26-2997d9fb0985> in <module>
----> 1 mplhep.hist2dplot(hist3d[:, :, sum]);

~/anaconda3/envs/hist/lib/python3.8/site-packages/mplhep/plot.py in hist2dplot(H, xbins, ybins, weights, labels, cbar, cbarsize, cbarpad, cbarpos, cmin, cmax, ax, **kwargs)
    386 ):
    387 
--> 388     H = H.T
    389 
    390     if ax is None:

AttributeError: 'Histogram' object has no attribute 'T'
```